### PR TITLE
Fix race condition with listeners and getSelectedIndex().

### DIFF
--- a/src/main/java/org/angmarch/views/NiceSpinner.java
+++ b/src/main/java/org/angmarch/views/NiceSpinner.java
@@ -131,6 +131,10 @@ public class NiceSpinner extends TextView {
                     position++;
                 }
 
+                // Need to set selected index before calling listeners or getSelectedIndex() can be
+                // reported incorrectly due to race conditions.
+                mSelectedIndex = position;
+
                 if (mOnItemClickListener != null) {
                     mOnItemClickListener.onItemClick(parent, view, position, id);
                 }
@@ -140,7 +144,6 @@ public class NiceSpinner extends TextView {
                 }
 
                 mAdapter.notifyItemSelected(position);
-                mSelectedIndex = position;
                 setText(mAdapter.getItemInDataset(position).toString());
                 dismissDropDown();
             }


### PR DESCRIPTION
If getSelectedIndex() is called from within an item click/selection listener it will report the previous value. This can cause race conditions if the onClick/Selection listener triggers a threaded operation. This pull request fixes that.