### PR TITLE
Fixed measure display crash

### DIFF
--- a/src/main/java/org/angmarch/views/NiceSpinner.java
+++ b/src/main/java/org/angmarch/views/NiceSpinner.java
@@ -1,7 +1,6 @@
 package org.angmarch.views;
 
 import android.animation.ObjectAnimator;
-import android.app.Activity;
 import android.content.Context;
 import android.content.res.Resources;
 import android.content.res.TypedArray;
@@ -17,7 +16,6 @@ import android.support.v4.graphics.drawable.DrawableCompat;
 import android.support.v4.view.animation.LinearOutSlowInInterpolator;
 import android.support.v7.widget.AppCompatTextView;
 import android.util.AttributeSet;
-import android.util.DisplayMetrics;
 import android.util.TypedValue;
 import android.view.Gravity;
 import android.view.MotionEvent;
@@ -210,12 +208,7 @@ public class NiceSpinner extends AppCompatTextView {
     }
 
     private void measureDisplayHeight() {
-        DisplayMetrics displayMetrics = new DisplayMetrics();
-        Activity activity = (Activity) getContext();
-        activity.getWindowManager()
-                .getDefaultDisplay()
-                .getMetrics(displayMetrics);
-        displayHeight = displayMetrics.heightPixels;
+        displayHeight = getContext().getResources().getDisplayMetrics().heightPixels;
     }
 
     private int getParentVerticalOffset() {


### PR DESCRIPTION
When the context of the spinner is a `ContextThemeWrapper` instead of an `Activity` the current `measureDisplayHeight()` method will crash when attempting to cast the context to Activity. 

Crash Log:

> Caused by: java.lang.ClassCastException: android.support.v7.view.ContextThemeWrapper cannot be cast to android.app.Activity
                                                                                                at org.angmarch.views.NiceSpinner.measureDisplayHeight(NiceSpinner.java:214)
                                                                                                at org.angmarch.views.NiceSpinner.init(NiceSpinner.java:209)
                                                                                                at org.angmarch.views.NiceSpinner.<init>(NiceSpinner.java:82)


This scenario can be replicated by placing the spinner inside a v7 Toolbar that has a `app:theme` applied, example:

Layout:
```
<?xml version="1.0" encoding="utf-8"?>
<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
    xmlns:tools="http://schemas.android.com/tools"
    android:layout_width="match_parent"
    android:layout_height="match_parent"
    xmlns:app="http://schemas.android.com/apk/res-auto"
    android:orientation="vertical">
    
    <android.support.v7.widget.Toolbar
        android:layout_width="match_parent"
        android:layout_height="?attr/actionBarSize"
        android:background="?colorPrimary"
        app:theme="@style/Toolbar"
        tools:subtitle="Subtitle"
        tools:title="Title">

        <org.angmarch.views.NiceSpinner
            android:id="@+id/nice_spinner"
            android:layout_width="200dp"
            android:layout_height="match_parent" />
    </android.support.v7.widget.Toolbar>
</LinearLayout>
```


Changed the measure method to instead use the `DisplayMetrics` from resources which can be retrieved from context rather than needing an `Activity`