### PR TITLE
update gradle wrapper to use stable version instead of snapshot

### DIFF
--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -3,5 +3,5 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions-snapshots/gradle-4.4-20171031235950+0000-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-4.4-all.zip
 


### PR DESCRIPTION
The current version of master doesn't build without this change.