### PR TITLE
Make spinner take max size available on screen

### DIFF
--- a/src/main/java/org/angmarch/views/NiceSpinner.java
+++ b/src/main/java/org/angmarch/views/NiceSpinner.java
@@ -360,8 +360,9 @@ public class NiceSpinner extends AppCompatTextView {
 
     private void measurePopUpDimension() {
         int widthSpec = MeasureSpec.makeMeasureSpec(getMeasuredWidth(), MeasureSpec.EXACTLY);
-        int heightSpec = MeasureSpec.makeMeasureSpec(
-                displayHeight - getParentVerticalOffset() - getMeasuredHeight(),
+        //Max height set to the maximum available size above or below the spinner
+        int maxHeight = Math.max(displayHeight - getParentVerticalOffset() - getMeasuredHeight(), getParentVerticalOffset());
+        int heightSpec = MeasureSpec.makeMeasureSpec(maxHeight,
                 MeasureSpec.AT_MOST);
         listView.measure(widthSpec, heightSpec);
         popupWindow.setWidth(listView.getMeasuredWidth());


### PR DESCRIPTION
This allows the popup to be bigger and when using a spinner in the bottom part of the screen, it shows the popup above the spinner