### PR TITLE
merge and fixed the issues.

### DIFF
--- a/library/src/main/java/org/angmarch/views/NiceSpinner.java
+++ b/library/src/main/java/org/angmarch/views/NiceSpinner.java
@@ -237,6 +237,14 @@ public class NiceSpinner extends AppCompatTextView {
         }
         super.onDetachedFromWindow();
     }
+    
+    @Override
+    protected void onAttachedToWindow() {
+        super.onAttachedToWindow();
+        if (Build.VERSION.SDK_INT <= Build.VERSION_CODES.KITKAT) {
+            onVisibilityChanged(this, getVisibility());
+        }
+    }
 
     @Override
     protected void onVisibilityChanged(View changedView, int visibility) {


### PR DESCRIPTION
merge and fixed the issues when the devices low than `KITKAT 4.4`.

If the component is mounted on a `Fragment` or `Window`

following the carsh message:
```java
    java.lang.NullPointerException
        at android.animation.PropertyValuesHolder.setupSetterAndGetter(PropertyValuesHolder.java:505)
        at android.animation.ObjectAnimator.initAnimation(ObjectAnimator.java:487)
        at android.animation.ValueAnimator.setCurrentPlayTime(ValueAnimator.java:517)
        at android.animation.ValueAnimator.start(ValueAnimator.java:936)
        at android.animation.ValueAnimator.start(ValueAnimator.java:946)
        at android.animation.ObjectAnimator.start(ObjectAnimator.java:465)
        at org.angmarch.views.NiceSpinner.a(NiceSpinner.java:375)
        at org.angmarch.views.NiceSpinner.b(NiceSpinner.java:387)
        at org.angmarch.views.NiceSpinner.onTouchEvent(NiceSpinner.java:362)
        .......
```
see #63 #39 

the mthod of `onVisibilityChanged(View changedView, int visibility)` does not excuted when the `isArrowHidden == false`  else the component not support.

@arcadefire