### PR TITLE
FEAT: hide keyboard when showing spinner options

### DIFF
--- a/library/src/main/java/org/angmarch/views/NiceSpinner.java
+++ b/library/src/main/java/org/angmarch/views/NiceSpinner.java
@@ -22,6 +22,7 @@ import android.util.TypedValue;
 import android.view.Gravity;
 import android.view.MotionEvent;
 import android.view.View;
+import android.view.inputmethod.InputMethodManager;
 import android.widget.AdapterView;
 import android.widget.ListAdapter;
 import android.widget.PopupWindow;
@@ -30,7 +31,6 @@ import android.widget.PopupWindow;
 import android.widget.ListPopupWindow;
 import android.widget.ListView;
 
-import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 
@@ -397,6 +397,8 @@ public class NiceSpinner extends AppCompatTextView {
     }
 
     public void showDropDown() {
+        InputMethodManager imm = (InputMethodManager) getContext().getSystemService(Context.INPUT_METHOD_SERVICE);
+        imm.hideSoftInputFromWindow(getWindowToken(), 0);
         if (!isArrowHidden) {
             animateArrow(true);
         }


### PR DESCRIPTION
Hide keyboard when showing options.

Use case:
- I have focus in edittext with opened keyboard
- When opening spinners options keyboard won't disappear and I am able to type
- Focus is still on edittext but text is not changing

This is not very nice behaviour

- When doing this on one plus 7 (with their gestures instead of the navigation buttons on bottom) everything freezes and I am not able to open keyboard again until I kill the app

**This is critical issue**