### PR TITLE
Fix icon position issue in rtl devices

### DIFF
--- a/library/src/main/java/org/angmarch/views/NiceSpinner.java
+++ b/library/src/main/java/org/angmarch/views/NiceSpinner.java
@@ -262,7 +262,11 @@ public class NiceSpinner extends AppCompatTextView {
 
     private void setArrowDrawableOrHide(Drawable drawable) {
         if (!isArrowHidden && drawable != null) {
-            setCompoundDrawablesWithIntrinsicBounds(null, null, drawable, null);
+            if (Build.VERSION.SDK_INT >= 17) {
+                setCompoundDrawablesRelativeWithIntrinsicBounds(null, null, drawable, null);
+            } else {
+                setCompoundDrawablesWithIntrinsicBounds(null, null, drawable, null);
+            }
         } else {
             setCompoundDrawablesWithIntrinsicBounds(null, null, null, null);
         }


### PR DESCRIPTION
Hi. The position of the icon in right-to-left languages, such as Persian, was incorrect.

This problem was also raised in two issues: #125 and #174

I hope I have been able to help develop this library.